### PR TITLE
User should be able to see their own subadmin groups

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -53,7 +53,7 @@ API::register('post', '/cloud/users/{userid}/groups', [$users, 'addToGroup'], 'p
 API::register('delete', '/cloud/users/{userid}/groups', [$users, 'removeFromGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('post', '/cloud/users/{userid}/subadmins', [$users, 'addSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('delete', '/cloud/users/{userid}/subadmins', [$users, 'removeSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::USER_AUTH);
 
 // Groups
 $groups = new Groups(

--- a/changelog/unreleased/38281
+++ b/changelog/unreleased/38281
@@ -1,0 +1,1 @@
+Bugfix: Allow all users to see which groups they manage


### PR DESCRIPTION
## Description
See related issue below.

## Related Issue
- Fixes https://github.com/owncloud/owncloud-sdk/issues/658

## Motivation and Context
When logging in, we want to check what groups a user is a subadmin of, so we know what UI to present them with if they can manage specific groups.

## How Has This Been Tested?
Works as expected, normal users can call the owncloud-sdk without an error response (even if they have are not a subadmin of the group).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
